### PR TITLE
[ui] #101 - 식당 상세페이지 탭 레이아웃 버튼 클릭 시 리플 효과 제거

### DIFF
--- a/app/src/main/res/layout/dialog_restaurant_detail.xml
+++ b/app/src/main/res/layout/dialog_restaurant_detail.xml
@@ -284,6 +284,7 @@
                     app:tabIndicator="@drawable/rectangle_border_radius_10"
                     app:tabIndicatorColor="@color/red_500"
                     app:tabIndicatorHeight="2dp"
+                    app:tabRippleColor="@null"
                     app:tabSelectedTextColor="@color/red_500"
                     app:tabTextAppearance="@style/TabItem.RestaurantTab.TextAppearance"
                     app:tabTextColor="@color/gray_600">


### PR DESCRIPTION
## Related issue 🚀
- closed #101

## Work Description 💚
- 식당 상세페이지 탭 레이아웃 버튼 클릭 시 리플 효과 제거
