### PR TITLE
[fix] #221 - 로그인에 실패하는 버그 수정

### DIFF
--- a/app/src/main/java/org/helfoome/data/model/response/ResponseLogin.kt
+++ b/app/src/main/java/org/helfoome/data/model/response/ResponseLogin.kt
@@ -16,10 +16,9 @@ data class ResponseLogin(
         @SerialName("_id")
         val id: String,
         val name: String,
-        val email: String?,
         val social: String,
         val socialId: String,
-        val email: String?,
+        val email: String? = null,
         val scrapRestaurants: List<String>,
         val refreshToken: String,
         val __v: Int


### PR DESCRIPTION
## Related issue 🚀
- closed #221

## Work Description 💚
- LoginInfo에서 email 필드는 nullable한 필드로 디폴트 값을 지정하여 예외 처리했습니다.
- 중복된 email 프로퍼티 제거
- [참고 자료](https://stackoverflow.com/questions/64796913/kotlinx-serialization-missingfieldexception)