### PR TITLE
[feat] 식당 상세 뷰에서 distance값 보여주기 및 단위 포맷 적용

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/MainActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainActivity.kt
@@ -397,7 +397,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
                         setOnClickListener {
                             viewModel.getReviewCheck(marker.id)
-                            viewModel.fetchSelectedRestaurantDetailInfo(marker.id, marker.latitude, marker.longitude)
+                            viewModel.fetchSelectedRestaurantDetailInfo(marker.id, locationSource.lastLocation?.latitude ?: marker.latitude, locationSource.lastLocation?.longitude ?: marker.longitude)
 
                             behavior.state = BottomSheetBehavior.STATE_COLLAPSED
                             binding.isMainNotVisible = true

--- a/app/src/main/java/org/helfoome/presentation/MainActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainActivity.kt
@@ -209,9 +209,11 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
             btnWriteReview.apply {
                 setOnClickListener {
-                    requestReviewWrite.launch(Intent(this@MainActivity, ReviewWritingActivity::class.java).putExtra(ARG_RESTAURANT_ID,
-                        viewModel?.selectedRestaurant?.value?.id ?: return@setOnClickListener)
-                        .putExtra("RESTAURANT_NAME", binding.layoutRestaurantDialog.tvRestaurantName.text.toString()))
+                    requestReviewWrite.launch(
+                        Intent(this@MainActivity, ReviewWritingActivity::class.java)
+                            .putExtra(ARG_RESTAURANT_ID, viewModel?.selectedRestaurant?.value?.id ?: return@setOnClickListener)
+                            .putExtra("RESTAURANT_NAME", binding.layoutRestaurantDialog.tvRestaurantName.text.toString())
+                    )
                 }
             }
         }
@@ -397,7 +399,11 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
                         setOnClickListener {
                             viewModel.getReviewCheck(marker.id)
-                            viewModel.fetchSelectedRestaurantDetailInfo(marker.id, locationSource.lastLocation?.latitude ?: marker.latitude, locationSource.lastLocation?.longitude ?: marker.longitude)
+                            viewModel.fetchSelectedRestaurantDetailInfo(
+                                marker.id,
+                                locationSource.lastLocation?.latitude ?: marker.latitude,
+                                locationSource.lastLocation?.longitude ?: marker.longitude
+                            )
 
                             behavior.state = BottomSheetBehavior.STATE_COLLAPSED
                             binding.isMainNotVisible = true

--- a/app/src/main/java/org/helfoome/presentation/search/SearchActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/search/SearchActivity.kt
@@ -125,9 +125,7 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
                     )
                 }
             }
-            mainViewModel.fetchSelectedRestaurantDetailInfo(restaurantId,
-                it.latitude,
-                it.longitude)
+            mainViewModel.fetchSelectedRestaurantDetailInfo(restaurantId, it.latitude, it.longitude)
         }
         searchViewModel.setDetail(true)
     }

--- a/app/src/main/java/org/helfoome/util/BindingAdapter.kt
+++ b/app/src/main/java/org/helfoome/util/BindingAdapter.kt
@@ -30,11 +30,10 @@ fun View.setSelected(isSelected: Boolean?) {
 fun TextView.setDistance(distance: Int?) {
     if (distance == null) return
     this.text = if (distance >= 1000) {
-        val df = DecimalFormat("#.#");
+        val df = DecimalFormat("#.#")
         val result = distance / 1000.0
         "${df.format(result)}km"
-    }
-    else {
+    } else {
         "${distance}m"
     }
 }

--- a/app/src/main/java/org/helfoome/util/BindingAdapter.kt
+++ b/app/src/main/java/org/helfoome/util/BindingAdapter.kt
@@ -2,9 +2,11 @@ package org.helfoome.util
 
 import android.view.View
 import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.databinding.BindingAdapter
 import coil.load
+import java.text.DecimalFormat
 
 @BindingAdapter("app:imageUrl")
 fun ImageView.setImage(imageUrl: String?) {
@@ -22,4 +24,17 @@ fun View.setVisibility(isVisible: Boolean?) {
 fun View.setSelected(isSelected: Boolean?) {
     if (isSelected == null) return
     this.isSelected = isSelected
+}
+
+@BindingAdapter("app:distance")
+fun TextView.setDistance(distance: Int?) {
+    if (distance == null) return
+    this.text = if (distance >= 1000) {
+        val df = DecimalFormat("#.#");
+        val result = distance / 1000.0
+        "${df.format(result)}km"
+    }
+    else {
+        "${distance}m"
+    }
 }

--- a/app/src/main/res/layout/dialog_restaurant_detail.xml
+++ b/app/src/main/res/layout/dialog_restaurant_detail.xml
@@ -288,10 +288,10 @@
                             android:drawableTop="@drawable/ic_navi"
                             android:drawablePadding="4dp"
                             android:fontFamily="@font/notosanskr_m"
-                            android:text="@{@string/restaurant_detail_navi_meter_format(viewModel.selectedRestaurant.distance)}"
                             android:textAllCaps="false"
                             android:textColor="@color/red_500"
                             android:textSize="12dp"
+                            app:distance="@{viewModel.selectedRestaurant.distance}"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintTop_toTopOf="@id/iv_location"
                             tools:text="589m" />


### PR DESCRIPTION
## Related issue 🚀
- closed #214

## Work Description 💚
- 식당 상세뷰에서 distance 값 보여주기
   - 기존 : 식당 상세뷰 조회 api 요청 시 위도, 경도값을 해당 식당의 위도, 경도 값으로 넘겨주어 distance가 항상 0으로 나왔음
   - 변경 : api 요청 시 현재 위치의 위도, 경도값을 넘겨줌
- 1000m 이상인 경우 km로 단위 변환
   - 소수점 첫째자리까지 출력. (단, 소수점 첫째자리가 0이라면 생략)

## Screenshot 📸
<img width="294" alt="image" src="https://user-images.githubusercontent.com/48701368/180830736-c0996ae7-2213-4857-82bf-bd99694cff57.png">
<img width="293" alt="image" src="https://user-images.githubusercontent.com/48701368/180830807-ad0b4213-ade0-496e-88fd-dc63c973c822.png">
