### PR TITLE
[fix] 마커 관련 버그 수정

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/MainActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainActivity.kt
@@ -101,6 +101,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                 }
             }
         }
+
         override fun onSlide(bottomSheetView: View, slideOffset: Float) = Unit
     }
 
@@ -260,15 +261,13 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                 startActivity(Intent(Intent.ACTION_DIAL, Uri.parse("tel:" + tvNumber.text)))
             }
 
-            binding.layoutSearch.setOnClickListener {
-                viewModel?.location?.value?.let {
-                    startActivity<SearchActivity>(Pair(MARKER_INFO, it))
-                }
-            }
-
             btnNavi.setOnClickListener {
                 showMapSelectionBottomDialog()
             }
+        }
+
+        binding.layoutSearch.setOnClickListener {
+            startActivity<SearchActivity>(MARKER_INFO to viewModel.defaultLocation)
         }
 
         with(binding.layoutDrawer) {
@@ -289,7 +288,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
             tvScrap.setOnClickListener {
                 controlHamburger.launch(
                     Intent(this@MainActivity, MyScrapActivity::class.java).apply {
-                        putExtras(bundleOf(Pair(MARKER_INFO, viewModel.location.value)))
+                        putExtras(bundleOf(MARKER_INFO to viewModel.defaultLocation))
                     }
                 )
             }

--- a/app/src/main/java/org/helfoome/presentation/MainViewModel.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainViewModel.kt
@@ -34,6 +34,9 @@ class MainViewModel @Inject constructor(
     val scrapList: LiveData<List<MarkerInfo>> = _scrapList
     private val _checkReview = MutableLiveData<Boolean>()
     val checkReview: LiveData<Boolean> = _checkReview
+
+    private val _defaultLocation = mutableListOf<MarkerInfo>()
+    val defaultLocation: List<MarkerInfo> = _defaultLocation
     private val _location = MutableLiveData<List<MarkerInfo>>()
     val location: LiveData<List<MarkerInfo>> = _location
     private val _isDietRestaurant = MutableLiveData<Boolean>()
@@ -116,6 +119,12 @@ class MainViewModel @Inject constructor(
                             marker.toMakerInfo()
                         }
                     )
+                    if (keyword == null) {
+                        with(_defaultLocation) {
+                            clear()
+                            addAll(it.data.map { marker -> marker.toMakerInfo() })
+                        }
+                    }
                 }.onFailure {
                     Timber.d(it.message)
                 }

--- a/app/src/main/java/org/helfoome/util/ext/ContextExt.kt
+++ b/app/src/main/java/org/helfoome/util/ext/ContextExt.kt
@@ -10,7 +10,7 @@ import androidx.core.os.bundleOf
 
 fun Context.showKeyboard(view: View) {
     val inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-    inputMethodManager.showSoftInput(view.findFocus(), 0)
+    inputMethodManager.showSoftInput(view, 0)
 }
 
 fun Context.closeKeyboard(view: View) {


### PR DESCRIPTION
## Related issue 🚀
- closed #259 closed #267 

## Work Description 💚
- 기존 필터 적용시 `Search` `Scrap`에서 마커가 이상하게 찍히는 버그 수정
### 원인 👀
**기존 방식의 경우**
<img width="613" alt="image" src="https://user-images.githubusercontent.com/70698151/188460577-1fe3590b-3b43-4b56-8189-4b137c2e3059.png">
필터가 수정될때마다 마커 리스트가 변경되는 `location 변수`를 `Intent`로 다른 뷰로 넘겨줘서 마커가 이상하게 찍혔던 것.
### 해결 👀
필터가 적용되지 않는 마커들의 정보를 보관하는 리스트를 따로 만들어 해당 변수를 `Intent`로 넘겨주는 식으로 로직 수정
<img width="618" alt="image" src="https://user-images.githubusercontent.com/70698151/188460883-fb2e42d1-aca7-4ee7-a7d3-04c702d39d76.png">

로직 더러움..
