### PR TITLE
[fix] #281 리뷰 업로드 시 별점 0.5점을 부여할 경우, 별점이 올바르게 표시되지 않는 버그를 수정

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/custom/StarScore.kt
+++ b/app/src/main/java/org/helfoome/presentation/custom/StarScore.kt
@@ -32,6 +32,7 @@ class StarScore(context: Context, val attrs: AttributeSet? = null) : ConstraintL
     }
 
     fun setScore(score: Float) {
+        Timber.d(score.toString())
         if (score in 0f..5f) setStarImage(score)
         else Timber.d("Invalid Score: Error")
     }
@@ -53,7 +54,8 @@ class StarScore(context: Context, val attrs: AttributeSet? = null) : ConstraintL
 
             // 소수점 첫째자리에 해당하는 아이콘 디스플레이
             if (score < 5.0f) {
-                starViewList[lastIdx + 1].setImageResource(getDecimalPointImageRes(firstDecimalPlace) ?: return)
+                if (integer == 0) starViewList[lastIdx].setImageResource(getDecimalPointImageRes(firstDecimalPlace) ?: return)
+                else starViewList[lastIdx + 1].setImageResource(getDecimalPointImageRes(firstDecimalPlace) ?: return)
             }
         }
     }


### PR DESCRIPTION
## Related issue 🚀
- closed #281

## Work Description 💚
- 0.5점과 같이 정수자리가 0인 경우, 아래 코드에 의해 2점 위치에 해당하는 별점 뷰에 0.5점이 칠해졌던 것이 원인이었습니다..

- 정수가 0인 경우에 해당하는 예외처리를 추가했습니다~
```kotlin
starViewList[lastIdx + 1].setImageResource(getDecimalPointImageRes(firstDecimalPlace) ?: return)
```
## Screenshot 📸(선택)
<수정 전>
<img width="120" alt="image" src="https://user-images.githubusercontent.com/48701368/189073617-c2f52e53-41fb-408c-8279-ad23138e3912.png">

<수정 후>
<img width="111" alt="image" src="https://user-images.githubusercontent.com/48701368/189072698-c8cfa474-551c-4df4-9a14-6964652e6600.png">