### PR TITLE
[fix] 내 리뷰 good 해시 태그 포맷 버그 수정

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/custom/HashtagView.kt
+++ b/app/src/main/java/org/helfoome/presentation/custom/HashtagView.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayout
+import org.helfoome.R
 import org.helfoome.databinding.ItemHashtagRestaurantSummaryBinding
 import org.helfoome.databinding.ItemHashtagReviewTabBinding
 import org.helfoome.presentation.type.HashtagViewType
@@ -23,7 +24,7 @@ class HashtagView(context: Context, attrs: AttributeSet? = null) : FlexboxLayout
         for (i in hashtag.indices) {
             val binding = when (viewType) {
                 HashtagViewType.REVIEW_TAB_TYPE -> ItemHashtagReviewTabBinding.inflate(inflater, this, false).apply {
-                    tvHashtag.text = String.format(context.getString(viewType.strRes ?: return), hashtag[i])
+                    tvHashtag.text = String.format(context.getString(R.string.format_hashtag), hashtag[i])
                 }
                 HashtagViewType.RESTAURANT_SUMMARY_TYPE -> ItemHashtagRestaurantSummaryBinding.inflate(inflater, this, false).apply {
                     tvHashtag.text = hashtag[i]

--- a/app/src/main/java/org/helfoome/presentation/drawer/adapter/MyReviewAdapter.kt
+++ b/app/src/main/java/org/helfoome/presentation/drawer/adapter/MyReviewAdapter.kt
@@ -14,7 +14,7 @@ import org.helfoome.util.ItemDiffCallback
 class MyReviewAdapter(
     private val startRestaurant: (() -> Unit),
     private val deleteReview: (String) -> Unit,
-    private val editReview: (MyReviewInfo) -> Unit
+    private val editReview: (MyReviewInfo) -> Unit,
 ) :
     ListAdapter<MyReviewInfo, MyReviewAdapter.MyReviewViewHolder>(
         ItemDiffCallback<MyReviewInfo>(
@@ -41,7 +41,7 @@ class MyReviewAdapter(
             myReviewData: MyReviewInfo,
             startRestaurant: () -> Unit,
             deleteClickListener: (String) -> Unit,
-            editClickListener: (MyReviewInfo) -> Unit
+            editClickListener: (MyReviewInfo) -> Unit,
         ) {
             with(binding) {
                 val adapter = RestaurantImageAdapter().apply {
@@ -61,7 +61,7 @@ class MyReviewAdapter(
                 tvEdit.setOnClickListener {
                     editClickListener.invoke(myReviewData)
                 }
-                binding.hashtag.setHashtag(listOf(myReviewData.taste, myReviewData.good.joinToString()), HashtagViewType.REVIEW_TAB_TYPE)
+                binding.hashtag.setHashtag(listOf(myReviewData.taste) + myReviewData.good, HashtagViewType.REVIEW_TAB_TYPE)
             }
         }
     }


### PR DESCRIPTION
## Related issue 🚀
- closed #283

## Work Description 💚
- good 해시태그가 "든든한", "양 조절 쉬운" 처럼 2개 이상이면 해시태그가 "든든한"과 "양 조절 쉬운" 두가지로 보여야하는데 "든든한, 양 조절 쉬운"으로 태그 내용이 하나로 합쳐서 보이는 버그가 있었습니다.
   - good 해시태그 리스트를 joinToString를 통해 하나의 문자열로 이어 붙였던 것이 원인이었습니다 ㅎㅎ joinToString 뭔데,, 킹받아

## Screenshot 📸(선택)
[수정 전]
<img width="194" alt="스크린샷 2022-09-12 오전 1 03 13" src="https://user-images.githubusercontent.com/48701368/189537739-f79a6562-cd17-43eb-a6b9-6ef2adf8c957.png">

[수정 후]
<img width="193" alt="image" src="https://user-images.githubusercontent.com/48701368/189537771-c6cf177e-b888-4683-8d41-a9d22700955e.png">
