### PR TITLE
[fix] 리뷰 작성 시 레스토랑 이름을 불러오지 못하는 버그를 수정

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/MainActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainActivity.kt
@@ -199,7 +199,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                         requestReviewWrite.launch(
                             Intent(this@MainActivity, ReviewWritingActivity::class.java)
                                 .putExtra(ARG_RESTAURANT_ID, viewModel?.selectedRestaurant?.value?.id ?: return@setOnClickListener)
-                                .putExtra("RESTAURANT_NAME", binding.layoutRestaurantDialog.tvRestaurantName.text.toString())
+                                .putExtra(ARG_RESTAURANT_NAME, binding.layoutRestaurantDialog.tvRestaurantName.text.toString())
                         )
                     }
                 }


### PR DESCRIPTION
## Related issue 🚀
- closed #291

## Work Description 💚
- 리뷰 작성 시 레스토랑 이름을 불러오지 못하는 버그를 수정
   - 인텐트로 레스토랑 이름 String값 전달 시 인텐트를 전달받는 곳의 name값과 일치하지 않아서 발생한 버그입니다 :)
