### PR TITLE
[feat] 식당 상세뷰 메뉴판 이미지 보여주기 구현

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/MainViewModel.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainViewModel.kt
@@ -75,6 +75,9 @@ class MainViewModel @Inject constructor(
     // Menu
     private val _menu = MutableLiveData<List<MenuInfo>>()
     val menu: LiveData<List<MenuInfo>> = _menu
+    private val _menuBoard = MutableLiveData<List<String>>()
+    val menuBoard: LiveData<List<String>> = _menuBoard
+
     private val _eatingOutTips = MutableLiveData<List<EatingOutTipInfo>>()
     val eatingOutTips get() = _eatingOutTips
 
@@ -209,6 +212,7 @@ class MainViewModel @Inject constructor(
             _selectedFoodCategoryIdx.value = 0
             _eatingOutTips.value = restaurantRepository.getEatingOutTips(restaurantId)
             _menu.value = restaurantInfo?.menuList?.sortedByDescending { it.isHealfoomePick }
+            restaurantInfo?.menuImages?.let { _menuBoard.value = it }
         }
     }
 

--- a/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantMenuTabFragment.kt
+++ b/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantMenuTabFragment.kt
@@ -38,8 +38,13 @@ class RestaurantMenuTabFragment : BindingFragment<FragmentMenuBinding>(R.layout.
         }
 
         viewModel.menuBoard.observe(viewLifecycleOwner) { menuBoardList ->
-            if (menuBoardList.isNullOrEmpty()) return@observe
-            restaurantMenuBoardAdapter.menuBoardList = menuBoardList
+            if (menuBoardList.isNullOrEmpty() || menuBoardList == listOf("")) {
+                binding.layoutMenuContainer.visibility = View.INVISIBLE
+                return@observe
+            } else {
+                binding.layoutMenuContainer.visibility = View.VISIBLE
+                restaurantMenuBoardAdapter.menuBoardList = menuBoardList
+            }
         }
     }
 }

--- a/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantMenuTabFragment.kt
+++ b/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantMenuTabFragment.kt
@@ -8,12 +8,14 @@ import org.helfoome.R
 import org.helfoome.databinding.FragmentMenuBinding
 import org.helfoome.presentation.MainViewModel
 import org.helfoome.presentation.restaurant.adapter.RestaurantMenuAdapter
+import org.helfoome.presentation.restaurant.adapter.RestaurantMenuBoardAdapter
 import org.helfoome.util.binding.BindingFragment
 
 @AndroidEntryPoint
 class RestaurantMenuTabFragment : BindingFragment<FragmentMenuBinding>(R.layout.fragment_menu) {
     private val viewModel: MainViewModel by activityViewModels()
     private val restaurantMenuAdapter = RestaurantMenuAdapter()
+    private val restaurantMenuBoardAdapter = RestaurantMenuBoardAdapter()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -24,12 +26,18 @@ class RestaurantMenuTabFragment : BindingFragment<FragmentMenuBinding>(R.layout.
 
     private fun initView() {
         binding.menuList.adapter = restaurantMenuAdapter
+        binding.rvMenuBoardList.adapter = restaurantMenuBoardAdapter
     }
 
     private fun initObservers() {
         viewModel.menu.observe(viewLifecycleOwner) { menuList ->
             if (menuList == null) return@observe
             restaurantMenuAdapter.menuList = menuList
+        }
+
+        viewModel.menuBoard.observe(viewLifecycleOwner) { menuBoardList ->
+            if (menuBoardList == null) return@observe
+            restaurantMenuBoardAdapter.menuBoardList = menuBoardList
         }
     }
 }

--- a/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantMenuTabFragment.kt
+++ b/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantMenuTabFragment.kt
@@ -20,6 +20,8 @@ class RestaurantMenuTabFragment : BindingFragment<FragmentMenuBinding>(R.layout.
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        binding.viewModel = viewModel
+
         initView()
         initObservers()
     }
@@ -36,7 +38,7 @@ class RestaurantMenuTabFragment : BindingFragment<FragmentMenuBinding>(R.layout.
         }
 
         viewModel.menuBoard.observe(viewLifecycleOwner) { menuBoardList ->
-            if (menuBoardList == null) return@observe
+            if (menuBoardList.isNullOrEmpty()) return@observe
             restaurantMenuBoardAdapter.menuBoardList = menuBoardList
         }
     }

--- a/app/src/main/java/org/helfoome/presentation/restaurant/adapter/RestaurantMenuBoardAdapter.kt
+++ b/app/src/main/java/org/helfoome/presentation/restaurant/adapter/RestaurantMenuBoardAdapter.kt
@@ -1,0 +1,40 @@
+package org.helfoome.presentation.restaurant.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import org.helfoome.databinding.ItemMenuBoardBinding
+
+class RestaurantMenuBoardAdapter : RecyclerView.Adapter<RestaurantMenuBoardAdapter.MenuBoardViewHolder>() {
+    private lateinit var inflater: LayoutInflater
+    private val _menuBoardList = mutableListOf<String>()
+    var menuBoardList: List<String> = _menuBoardList
+        set(value) {
+            _menuBoardList.clear()
+            _menuBoardList.addAll(value)
+            notifyDataSetChanged()
+        }
+
+    class MenuBoardViewHolder(private val binding: ItemMenuBoardBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(menuBoardImgUrl: String) {
+            binding.ivImage.load(menuBoardImgUrl)
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MenuBoardViewHolder {
+        if (!::inflater.isInitialized)
+            inflater = LayoutInflater.from(parent.context)
+
+        val binding =
+            ItemMenuBoardBinding.inflate(inflater, parent, false)
+        return MenuBoardViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(viewHolder: MenuBoardViewHolder, position: Int) {
+        viewHolder.bind(menuBoardList[position])
+    }
+
+    override fun getItemCount(): Int = menuBoardList.size
+}

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -6,8 +6,6 @@
 
     <data>
 
-        <import type="android.view.View" />
-
         <variable
             name="viewModel"
             type="org.helfoome.presentation.MainViewModel" />
@@ -34,11 +32,11 @@
                 tools:listitem="@layout/item_menu" />
 
             <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/layout_menu_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/size_spacing_20"
                 android:paddingBottom="@dimen/size_spacing_30"
-                android:visibility="@{viewModel.menuBoard.size() > 0 ? View.VISIBLE : View.INVISIBLE}"
                 app:layout_constraintTop_toBottomOf="@id/menu_list">
 
                 <TextView

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -4,6 +4,15 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".presentation.restaurant.RestaurantMenuTabFragment">
 
+    <data>
+
+        <import type="android.view.View" />
+
+        <variable
+            name="viewModel"
+            type="org.helfoome.presentation.MainViewModel" />
+    </data>
+
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -29,13 +38,14 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/size_spacing_20"
                 android:paddingBottom="@dimen/size_spacing_30"
+                android:visibility="@{viewModel.menuBoard.size() > 0 ? View.VISIBLE : View.INVISIBLE}"
                 app:layout_constraintTop_toBottomOf="@id/menu_list">
 
                 <TextView
                     android:id="@+id/tv_menu_board_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/size_spacing_26"
+                    android:layout_marginTop="@dimen/size_spacing_6"
                     android:fontFamily="@font/notosanskr_b"
                     android:text="@string/restuarant_detail_memu_view_all"
                     android:textColor="@color/gray_800"
@@ -46,11 +56,11 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/rv_menu_board_list"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="102dp"
                     android:layout_marginTop="@dimen/size_spacing_16"
                     android:clipToPadding="false"
                     android:orientation="horizontal"
-                    android:paddingEnd="@dimen/size_spacing_16"
+                    android:paddingEnd="@dimen/size_spacing_12"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintTop_toBottomOf="@id/tv_menu_board_title"
                     tools:listitem="@layout/item_menu_board" />

--- a/app/src/main/res/layout/fragment_menu.xml
+++ b/app/src/main/res/layout/fragment_menu.xml
@@ -15,13 +15,47 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/menu_list"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/size_spacing_20"
                 android:clipToPadding="false"
                 android:paddingTop="5dp"
                 android:paddingBottom="@dimen/size_spacing_20"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintTop_toTopOf="parent"
                 tools:listitem="@layout/item_menu" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/size_spacing_20"
+                android:paddingBottom="@dimen/size_spacing_30"
+                app:layout_constraintTop_toBottomOf="@id/menu_list">
+
+                <TextView
+                    android:id="@+id/tv_menu_board_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/size_spacing_26"
+                    android:fontFamily="@font/notosanskr_b"
+                    android:text="@string/restuarant_detail_memu_view_all"
+                    android:textColor="@color/gray_800"
+                    android:textSize="14dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_menu_board_list"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/size_spacing_16"
+                    android:clipToPadding="false"
+                    android:orientation="horizontal"
+                    android:paddingEnd="@dimen/size_spacing_16"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:layout_constraintTop_toBottomOf="@id/tv_menu_board_title"
+                    tools:listitem="@layout/item_menu_board" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
 </layout>

--- a/app/src/main/res/layout/item_menu_board.xml
+++ b/app/src/main/res/layout/item_menu_board.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingEnd="@dimen/size_spacing_8">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_image"
+            android:layout_width="102dp"
+            android:layout_height="@dimen/size_spacing_0"
+            android:scaleType="centerCrop"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearanceOverlay="@style/CircleImageView.Radius.8.Style"
+            tools:background="@drawable/ic_helfoome_place_holder" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="restaurant_detail_eating_out_empty_view_description">해당되는 카테고리에\n관련된 외식대처법은 준비중입니다</string>
     <string name="restaurant_detail_eating_out_empty_view_guide">조금만 기다려 주세요!</string>
     <string name="restaurant_detail_review_empty_view_guide">아직 작성된 리뷰가 없습니다\n첫 리뷰를 작성해 주세요</string>
+    <string name="restuarant_detail_memu_view_all">메뉴 전체보기</string>
 
     <!--Search-->
     <string name="search_restaurant_food">식당, 음식 검색</string>


### PR DESCRIPTION
## Related issue 🚀
- closed #265

## Work Description 💚
- 식당 상세뷰 메뉴 탭 하단에 메뉴판 이미지 리스트 뷰를 추가했습니다 :)

## Screenshot 📸
- 메뉴판 이미지가 존재하는 경우 
   - 현재 메뉴판 이미지를 제공하는 레스토랑이 없기때문에 더미데이터를 넣어봤습니다 ^^
<img width="220" alt="image" src="https://user-images.githubusercontent.com/48701368/191677224-39489baa-4569-48b2-a323-d3d4ba847952.png">

</br>

- 메뉴판 이미지가 존재하지 않은 경우
<img width="210" alt="image" src="https://user-images.githubusercontent.com/48701368/191680633-aaa4dc39-739b-4a84-92fa-bb4947377a22.png">

## Uncompleted Tasks 😂
- [ ] 메뉴판 이미지 클릭 시 보여질 이미지 뷰어는 피그마에서 뷰가 업로드 되어있지 않은 것으로 확인되어 디자인 선생님들께 질문 갈기겠습니다! 뷰 확인된 이후 구현할 예정입니다!  #316
