### PR TITLE
[mod] 상세뷰에서 메뉴의 칼로리 및 1회 제공량 데이터가 존재하지 않는 경우 ui 수정

### DIFF
--- a/app/src/main/res/layout/item_menu.xml
+++ b/app/src/main/res/layout/item_menu.xml
@@ -101,7 +101,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/notosanskr_b"
-                    android:text="@{menu.calorie == null ? `-` : Integer.toString(menu.calorie)}"
+                    android:text="@{menu.calorie == -1 ? `-` : Integer.toString(menu.calorie)}"
                     android:textColor="@color/white"
                     android:textSize="@dimen/size_spacing_16"
                     tools:text="219" />
@@ -119,7 +119,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/notosanskr_m"
-                    android:text="@{menu.gramPerPerson == null ? context.getString(R.string.restaurant_detail_gram_per_person_for_empty) : String.format(context.getString(R.string.restaurant_detail_gram_per_person), menu.gramPerPerson)}"
+                    android:text="@{menu.gramPerPerson == -1 ? context.getString(R.string.restaurant_detail_gram_per_person_for_empty) : String.format(context.getString(R.string.restaurant_detail_gram_per_person), menu.gramPerPerson)}"
                     android:textColor="@color/white"
                     android:textSize="@dimen/size_spacing_10"
                     tools:text="(50g당)" />


### PR DESCRIPTION
## Related issue 🚀
- closed #313

## Work Description 💚
- 메뉴의 칼로리 및 1회 제공량 데이터가 존재하지 않는 경우 값을 null -> -1로 전달해주는 것으로 변경됨에 따라 -1인 경우 "-"로 표기하도록 수정했습니다!

## Screenshot 📸
<img width="218" alt="image" src="https://user-images.githubusercontent.com/48701368/191686906-59b36e19-17ba-4679-ab60-58ea3d3cbda7.png">

