### PR TITLE
[mod] 리뷰 관련 reponse 수정 및 헬푸미 리뷰 조회 버그 수정

### DIFF
--- a/app/src/main/java/org/helfoome/data/model/response/ResponseHFMReview.kt
+++ b/app/src/main/java/org/helfoome/data/model/response/ResponseHFMReview.kt
@@ -6,6 +6,7 @@ import org.helfoome.domain.entity.HFMReviewInfo
 
 @Serializable
 data class ResponseHFMReview(
+    @SerialName("_id")
     val id: String,
     val writer: String,
     val score: Float,

--- a/app/src/main/java/org/helfoome/data/model/response/ResponseMyReviewEdit.kt
+++ b/app/src/main/java/org/helfoome/data/model/response/ResponseMyReviewEdit.kt
@@ -5,23 +5,23 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ResponseMyReviewEdit(
-    @SerialName("__v")
-    val v: Int,
     @SerialName("_id")
     val id: String,
-    val content: String,
-    val good: List<String>,
-    val image: List<Image>,
+    val restaurantId: String,
     val restaurant: String,
+    val writerId: String,
+    val writer: String,
     val score: Double,
+    val content: String,
+    val image: List<Image>,
     val taste: String,
-    val writer: String
+    val good: List<String>,
 ) {
     @Serializable
     data class Image(
         @SerialName("_id")
         val id: String,
         val name: String,
-        val url: String
+        val url: String,
     )
 }

--- a/app/src/main/java/org/helfoome/data/model/response/ResponseMyReviewList.kt
+++ b/app/src/main/java/org/helfoome/data/model/response/ResponseMyReviewList.kt
@@ -7,9 +7,10 @@ import org.helfoome.domain.entity.ReviewImage
 
 @Serializable
 data class ResponseMyReviewList(
+    @SerialName("_id")
+    val id: String,
     val content: String,
     val good: List<String>,
-    val id: String,
     val image: List<Image>,
     val restaurant: String,
     val score: Float,

--- a/app/src/main/java/org/helfoome/data/model/response/ResponseReview.kt
+++ b/app/src/main/java/org/helfoome/data/model/response/ResponseReview.kt
@@ -9,15 +9,15 @@ import org.helfoome.domain.entity.ReviewImage
 data class ResponseReview(
     @SerialName("_id")
     val id: String,
-    @SerialName("__v")
-    val v: Int,
+    val restaurantId: String,
+    val restaurant: String,
+    val writerId: String,
+    val writer: String,
+    val score: Float,
     val content: String,
     val image: List<Image>,
-    val restaurant: String,
-    val score: Float,
-    val good: List<String>,
     val taste: String,
-    val writer: String,
+    val good: List<String>,
 ) {
     @Serializable
     data class Image(

--- a/app/src/main/java/org/helfoome/data/service/ReviewService.kt
+++ b/app/src/main/java/org/helfoome/data/service/ReviewService.kt
@@ -25,7 +25,7 @@ interface ReviewService {
     ): BaseResponse<List<ResponseMyReviewList>>
 
     @Multipart
-    @POST("/review/user/{userId}/restaurant/{restaurantId}")
+    @POST("/review/{userId}/{restaurantId}")
     suspend fun postHFMReview(
         @Path("userId") userId: String,
         @Path("restaurantId") restaurantId: String,

--- a/app/src/main/java/org/helfoome/data/service/ReviewService.kt
+++ b/app/src/main/java/org/helfoome/data/service/ReviewService.kt
@@ -53,7 +53,7 @@ interface ReviewService {
         @Part image: List<MultipartBody.Part>
     ): BaseResponse<ResponseMyReviewEdit>
 
-    @GET("/review/check/{userId}/{restaurantId}")
+    @GET("/user/check/{userId}/{restaurantId}")
     suspend fun getReviewCheck(
         @Path("userId") userId: String,
         @Path("restaurantId") restaurantId: String

--- a/app/src/main/java/org/helfoome/presentation/MainViewModel.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainViewModel.kt
@@ -220,6 +220,7 @@ class MainViewModel @Inject constructor(
             _selectedFoodCategoryIdx.value = 0
             _eatingOutTips.value = restaurantRepository.getEatingOutTips(restaurantId)
             _menu.value = restaurantInfo?.menuList?.sortedByDescending { it.isHealfoomePick }
+            fetchHFMReviewList()
             restaurantInfo?.menuImages?.let { _menuBoard.value = it }
         }
     }

--- a/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantReviewTabFragment.kt
+++ b/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantReviewTabFragment.kt
@@ -31,7 +31,6 @@ class RestaurantReviewTabFragment : BindingFragment<FragmentReviewBinding>(R.lay
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewModel.fetchHFMReviewList()
         initView()
         initObservers()
     }

--- a/app/src/main/java/org/helfoome/presentation/review/RestaurantReviewWritingViewModel.kt
+++ b/app/src/main/java/org/helfoome/presentation/review/RestaurantReviewWritingViewModel.kt
@@ -151,6 +151,7 @@ class RestaurantReviewWritingViewModel @Inject constructor(
             }
         }
 
+        // TODO ReviewRepository로 이동
         viewModelScope.launch {
             runCatching {
                 reviewService.putMyReviewEdit(

--- a/app/src/main/java/org/helfoome/presentation/review/ReviewWritingActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/review/ReviewWritingActivity.kt
@@ -109,7 +109,7 @@ class ReviewWritingActivity : BindingActivity<ActivityReviewWritingBinding>(R.la
             }
         }
         viewModel.isCompletedReviewUpload.observe(this) {
-            if (it) onBackPressed()
+            if (it) finish()
         }
         viewModel.isReviewModify.observe(this) {
             if (it) {


### PR DESCRIPTION
## Related issue 🚀
- closed #326 
- closed #329

## Work Description 💚
- 리뷰 관련 api 변경에 따른 DTO 및 api url을 수정했습니다 :) 관련 api는 다음과 같습니당!
   - 유저 리뷰 모아보기
   - 리뷰 작성
   - 헬푸미 리뷰 조회
   - 리뷰 편집
   - 리뷰 작성 확인
- 모든 식당뷰에서 동일 헬푸미 리뷰 리스트가 보이는 버그를 수정했습니다!
   - 리뷰탭 프래그먼트 처음 진입 시에만 리뷰를 fetch했기 때문에 발생한 버그로(식당뷰가 교체되어보이는 것처럼 보이지만 실제로는 뷰는 그대로 있고 데이터만 교체하고 있는 상황) 선택된 식당핀이 변경될 때마다 리뷰 조회 api를 호출하도록 수정했습니다~~
