### PR TITLE
[fix] 영업정보 없음 TextView와 전화번호 TextView가 겹쳐보이는 버그 수정

### DIFF
--- a/app/src/main/res/layout/fragment_restaurant_detail.xml
+++ b/app/src/main/res/layout/fragment_restaurant_detail.xml
@@ -230,21 +230,22 @@
                             android:layout_marginStart="@dimen/size_spacing_16"
                             android:layout_marginTop="@dimen/size_spacing_8"
                             android:text="@{viewModel.selectedRestaurant.time}"
+                            android:visibility="@{viewModel.selectedRestaurant.time != null &amp;&amp; viewModel.selectedRestaurant.time.empty == false ? View.VISIBLE : View.INVISIBLE}"
                             app:layout_constraintStart_toEndOf="@id/iv_time"
                             app:layout_constraintTop_toBottomOf="@id/tv_location"
-                            app:visibility="@{viewModel.selectedRestaurant.time != null &amp;&amp; viewModel.selectedRestaurant.time.empty == false}" />
+                            tools:visibility="invisible" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="@dimen/size_spacing_16"
-                            android:layout_marginTop="@dimen/size_spacing_8"
                             android:fontFamily="@font/notosanskr_m"
                             android:text="영업정보 없음"
                             android:textColor="@color/gray_600"
                             android:textSize="@dimen/size_spacing_12"
+                            app:layout_constraintBottom_toBottomOf="@+id/view_opening_time"
                             app:layout_constraintStart_toEndOf="@id/iv_time"
-                            app:layout_constraintTop_toBottomOf="@id/tv_location"
+                            app:layout_constraintTop_toTopOf="@id/view_opening_time"
                             app:visibility="@{viewModel.selectedRestaurant.time == null || viewModel.selectedRestaurant.time.empty}" />
 
                         <ImageView


### PR DESCRIPTION
## Related issue 🚀
- closed #341

## Work Description 💚
- 상세뷰에서 영업 정보가 존재하지 않을 때, 영업정보 없음 TextView와 전화번호 TextView가 겹쳐보이는 버그를 수정했습니다!
   - 각 뷰의 visibility 옵션을 수정


## Screenshot 📸(선택)
- 수정 후
<img width="186" alt="image" src="https://user-images.githubusercontent.com/48701368/192200526-3219b2ea-fd34-4f58-a08e-388cb0d9fe42.png">

- 수정 전
<img width="186" alt="image" src="https://user-images.githubusercontent.com/48701368/192200362-db26bc1f-0f8a-454b-8f3f-6c9d9cff9f2d.png">
