### PR TITLE
[fix] 상세뷰 영업시간 토글을 펼친 상태에서 다른 식당 핀을 눌렀을 경우, 여전히 토글이 펼쳐저 있...

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/MainActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainActivity.kt
@@ -114,8 +114,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         initNaverMap()
         initListeners()
         initObservers()
-
-        replace<RestaurantDetailFragment>(R.id.fragment_container_detail)
     }
 
     private fun provideChipClickListener(chip: Chip) =
@@ -310,6 +308,8 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                                         locationSource.lastLocation?.longitude ?: marker.longitude
                                     )
                                 }
+
+                                replace<RestaurantDetailFragment>(R.id.fragment_container_detail)
                                 behavior.state = BottomSheetBehavior.STATE_COLLAPSED
                                 markerList.forEach {
                                     it.first.icon = OverlayImage.fromResource(
@@ -321,6 +321,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                                     if (marker.isDietRestaurant) R.drawable.ic_marker_green_big
                                     else R.drawable.ic_marker_red_big
                                 )
+
                                 viewModel.markerId(this.position)?.let { id -> }
                                 true
                             }
@@ -360,6 +361,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                                 )
                             }
 
+                            replace<RestaurantDetailFragment>(R.id.fragment_container_detail)
                             behavior.state = BottomSheetBehavior.STATE_COLLAPSED
                             markerList.forEach {
                                 it.first.icon = OverlayImage.fromResource(

--- a/app/src/main/java/org/helfoome/presentation/scrap/MapSelectActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/scrap/MapSelectActivity.kt
@@ -167,6 +167,7 @@ class MapSelectActivity : BindingActivity<ActivityMapSelectBinding>(R.layout.act
                                 locationSource.lastLocation?.longitude ?: marker.longitude
                             )
 
+                            replace<RestaurantDetailFragment>(R.id.fragment_container_detail)
                             behavior.state = BottomSheetBehavior.STATE_COLLAPSED
                             markerList.forEach {
                                 it.first.icon = OverlayImage.fromResource(

--- a/app/src/main/java/org/helfoome/presentation/search/SearchActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/search/SearchActivity.kt
@@ -386,6 +386,7 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
                                                     marker.longitude
                                                 )
 
+                                                replace<RestaurantDetailFragment>(R.id.fragment_container_detail)
                                                 behavior.state = BottomSheetBehavior.STATE_COLLAPSED
                                                 binding.isMainNotVisible = true
                                                 markerList.forEach {


### PR DESCRIPTION
## Related issue 🚀
- closed #363

## Work Description 💚
- 디테일 뷰 전반적으로 여러 작업하다가 다른 핀 누를 경우 해당 작업들이 반영된채로 넘어가는 경우가 많음
- 그래서 replace로직 호출 위치를 바꿔서 이런 점 해결