### PR TITLE
[feat] 상세뷰 영업시간 토글 펼쳤을 때 현재 요일 볼드 처리

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/custom/OpeningTimeView.kt
+++ b/app/src/main/java/org/helfoome/presentation/custom/OpeningTimeView.kt
@@ -29,17 +29,17 @@ class OpeningTimeView(context: Context, attrs: AttributeSet? = null) : Constrain
 
     private fun initListeners() {
         binding.btnDropdown.setOnClickListener {
-            controlVisibility()
+            controlViewAttr()
         }
         binding.layoutNextday.setOnClickListener {
-            controlVisibility()
+            controlViewAttr()
         }
         binding.tvToday.setOnClickListener {
-            controlVisibility()
+            controlViewAttr()
         }
     }
 
-    private fun controlVisibility() {
+    private fun controlViewAttr() {
         with(binding) {
             btnDropdown.isSelected = !btnDropdown.isSelected
             tvToday.typeface = resources.getFont(if (btnDropdown.isSelected) R.font.notosanskr_b else R.font.notosanskr_m)

--- a/app/src/main/java/org/helfoome/presentation/custom/OpeningTimeView.kt
+++ b/app/src/main/java/org/helfoome/presentation/custom/OpeningTimeView.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
+import org.helfoome.R
 import org.helfoome.databinding.ViewOpeningTimeBinding
 import org.helfoome.util.DateUtil
 
@@ -41,6 +42,7 @@ class OpeningTimeView(context: Context, attrs: AttributeSet? = null) : Constrain
     private fun controlVisibility() {
         with(binding) {
             btnDropdown.isSelected = !btnDropdown.isSelected
+            tvToday.typeface = resources.getFont(if (btnDropdown.isSelected) R.font.notosanskr_b else R.font.notosanskr_m)
             layoutNextday.visibility = if (btnDropdown.isSelected) {
                 View.VISIBLE
             } else {


### PR DESCRIPTION
## Related issue 🚀
- closed #367

## Work Description 💚
- 상세뷰 영업시간 토글을 펼쳤을 때 현재 요일을 볼드 처리했습니다!
- 기존에 토글 클릭 이벤트를 처리하고 있는 함수에 볼드 처리 로직을 추가하면서 함수명을 `controlVisibility` -> `controlViewAttr`로 변경했습니다!

## Screenshot 📸
- 토글 펼쳤을 때
<img width="360" alt="image" src="https://user-images.githubusercontent.com/48701368/193168104-a7407a7e-c133-406a-817a-93585bc2eae1.png">

- 토글 접었을 때
<img width="360" alt="image" src="https://user-images.githubusercontent.com/48701368/193168148-5438622e-0829-448e-97dc-bcaed13488e0.png">
