### PR TITLE
[fix] #368 - 상세뷰 외식 대처법 글자 짤림 버그 수정

### DIFF
--- a/app/src/main/res/layout/item_eating_out_tip.xml
+++ b/app/src/main/res/layout/item_eating_out_tip.xml
@@ -18,13 +18,14 @@
 
         <TextView
             android:id="@+id/tv_advise"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/size_spacing_10"
             android:layout_marginTop="1dp"
             android:fontFamily="@font/notosanskr_r"
             android:textColor="@color/gray_800"
             android:textSize="@dimen/size_spacing_12"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/iv_check"
             app:layout_constraintTop_toTopOf="@id/iv_check"
             tools:text="먹는 속도가 자연스럽게 느려져요" />


### PR DESCRIPTION
## Related issue 🚀
- closed #368

## Work Description 💚
- 상세뷰 외식 대처법 내용에 해당하는 TextView의 오른쪽 가장자리에서 글자 짤림 버그를 수정했습니다!
   - TextView의 width를 0dp를 추가하고 배치 제약 조건 end를 추가했습니다!

## Screenshot 📸
식당 리나스 강남의 외식대처법을 조회한 것입니다!

- 수정 후
<img width="360" alt="image" src="https://user-images.githubusercontent.com/48701368/193168931-3caa65bb-dcb0-4b1d-80db-c36bf5b29116.png">

- 수정 전
<img width="360" alt="image" src="https://user-images.githubusercontent.com/48701368/193169031-33c6ec54-07fe-4bfe-a5c4-8dd54597d8f5.png">

