### PR TITLE
[feat] 레이아웃 취급방침 메뉴 임시로 추가

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/drawer/SettingActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/drawer/SettingActivity.kt
@@ -66,8 +66,12 @@ class SettingActivity : BindingActivity<ActivitySettingBinding>(R.layout.activit
 
     private fun goToPrivacyPolicyPage() {
         try {
-            startActivity(Intent(Intent.ACTION_VIEW,
-                Uri.parse("https://chipped-hamburger-edb.notion.site/v-1-0-12ab557bcb7e45fe9308ad17177828d0")))
+            startActivity(
+                Intent(
+                    Intent.ACTION_VIEW,
+                    Uri.parse("https://chipped-hamburger-edb.notion.site/v-1-0-12ab557bcb7e45fe9308ad17177828d0")
+                )
+            )
             return
         } catch (e: ActivityNotFoundException) {
             e.printStackTrace()

--- a/app/src/main/java/org/helfoome/presentation/drawer/SettingActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/drawer/SettingActivity.kt
@@ -1,6 +1,7 @@
 package org.helfoome.presentation.drawer
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -45,6 +46,9 @@ class SettingActivity : BindingActivity<ActivitySettingBinding>(R.layout.activit
                 setResult(Activity.RESULT_OK)
                 finish()
             }
+            tvPrivacyPolicy.setOnClickListener {
+                goToPrivacyPolicyPage()
+            }
         }
     }
 
@@ -58,5 +62,15 @@ class SettingActivity : BindingActivity<ActivitySettingBinding>(R.layout.activit
         emailIntent.putExtra(Intent.EXTRA_SUBJECT, "Subject")
         emailIntent.putExtra(Intent.EXTRA_TEXT, "Body")
         startActivity(Intent.createChooser(emailIntent, "Send email..."))
+    }
+
+    private fun goToPrivacyPolicyPage() {
+        try {
+            startActivity(Intent(Intent.ACTION_VIEW,
+                Uri.parse("https://chipped-hamburger-edb.notion.site/v-1-0-12ab557bcb7e45fe9308ad17177828d0")))
+            return
+        } catch (e: ActivityNotFoundException) {
+            e.printStackTrace()
+        }
     }
 }

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -58,16 +58,28 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/line_first" />
 
+        <!-- TODO 배치 수정 필요 -->
+        <TextView
+            android:id="@+id/tv_privacy_policy"
+            style="@style/TextView.Setting.TextAppearance_16"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/size_spacing_24"
+            android:layout_marginHorizontal="@dimen/size_spacing_20"
+            android:text="@string/setting_privacy_policy"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_customer_support" />
+
         <TextView
             android:id="@+id/tv_inquiry"
             style="@style/TextView.Setting.TextAppearance_16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/size_spacing_20"
-            android:layout_marginTop="@dimen/size_spacing_24"
+            android:layout_marginTop="@dimen/size_spacing_36"
             android:text="@string/setting_inquiry"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_customer_support" />
+            app:layout_constraintTop_toBottomOf="@id/tv_privacy_policy" />
 
         <TextView
             android:id="@+id/tv_withdrawal"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,4 +211,5 @@
     <string name="friday">금요일</string>
     <string name="saturday">토요일</string>
     <string name="sunday">일요일</string>
+    <string name="setting_privacy_policy">개인정보 취급방침</string>
 </resources>


### PR DESCRIPTION
## Related issue 🚀
- closed #397

## Work Description 💚
- 리젝 방지를 위해 개인정보 취급방침 메뉴를 설정화면에 추가했습니다!
   - 둘러보기와 로그인 시 보여지는 설정 화면 레이아웃이 달라짐에 따라 개인정보 취급방침 메뉴를 임시로 최상단에 두었습니다..
   - 최하단에 두고 싶었지만 둘러보기 진입 여부에 따라 고려해야할 레이아웃 배치 조건이 까다로웠기 때문이죠
   - 릴리즈 이후에 수정하도록 하겠습니다

## Uncompleted Tasks 😂
- [ ] 개인정보 취급방침 메뉴 배치 수정 필요
