### PR TITLE
[mod] - 상세뷰 상단바 하단에 그림자 제거

### DIFF
--- a/app/src/main/res/layout/fragment_restaurant_detail.xml
+++ b/app/src/main/res/layout/fragment_restaurant_detail.xml
@@ -84,7 +84,8 @@
                 android:id="@+id/layout_app_bar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@android:color/transparent">
+                android:background="@android:color/transparent"
+                app:elevation="0dp">
 
                 <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:layout_width="match_parent"


### PR DESCRIPTION
## Related issue 🚀
- closed #361

## Work Description 💚
- 상세뷰 앱바 하단의 elevation을 0dp로 설정했습니다!

## Screenshot 📸
- 수정 후
<img width="360" alt="image" src="https://user-images.githubusercontent.com/48701368/193482908-c77154af-96f9-4ad9-94c1-4b78dd88b8ff.png">

<br>

- 수정 전
<img width="360" alt="image" src="https://user-images.githubusercontent.com/48701368/193482945-6c6ff9f3-f5cb-4b03-b603-7326b97589e8.png">

