### PR TITLE
[mod] 설정탭 레이아웃 둘러보기 분기처리

### DIFF
--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -48,68 +48,72 @@
 
         <TextView
             android:id="@+id/tv_customer_support"
-            style="@style/TextView.Setting.TextAppearance_14"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/size_spacing_20"
             android:layout_marginTop="32dp"
             android:text="@string/setting_customer_support"
+            android:textAppearance="@style/TextView.Setting.TextAppearance_14"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/line_first" />
 
         <TextView
             android:id="@+id/tv_inquiry"
-            style="@style/TextView.Setting.TextAppearance_16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/size_spacing_20"
-            android:layout_marginTop="@dimen/size_spacing_24"
+            android:layout_marginTop="@dimen/size_spacing_12"
+            android:paddingVertical="@dimen/size_spacing_12"
             android:text="@string/setting_inquiry"
+            android:textAppearance="@style/TextView.Setting.TextAppearance_16"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_customer_support" />
 
         <TextView
             android:id="@+id/tv_declaration"
-            style="@style/TextView.Setting.TextAppearance_16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/size_spacing_20"
-            android:layout_marginTop="@dimen/size_spacing_36"
+            android:layout_marginTop="@dimen/size_spacing_12"
+            android:paddingVertical="@dimen/size_spacing_12"
             android:text="@string/setting_declaration"
+            android:textAppearance="@style/TextView.Setting.TextAppearance_16"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_inquiry" />
 
         <TextView
             android:id="@+id/tv_withdrawal"
-            style="@style/TextView.Setting.TextAppearance_16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/size_spacing_20"
-            android:layout_marginTop="@dimen/size_spacing_36"
+            android:layout_marginTop="@dimen/size_spacing_12"
+            android:paddingVertical="@dimen/size_spacing_12"
             android:text="@string/setting_withdrawal"
+            android:textAppearance="@style/TextView.Setting.TextAppearance_16"
             android:visibility="@{viewModel.getIsGuestLogin() ? View.GONE : View.VISIBLE}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_declaration" />
 
         <TextView
             android:id="@+id/tv_terms_policies"
-            style="@style/TextView.Setting.TextAppearance_14"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/size_spacing_20"
             android:layout_marginTop="76dp"
             android:text="@string/setting_terms_policies"
+            android:textAppearance="@style/TextView.Setting.TextAppearance_14"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_withdrawal" />
 
         <TextView
             android:id="@+id/tv_privacy_policy"
-            style="@style/TextView.Setting.TextAppearance_16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/size_spacing_20"
-            android:layout_marginTop="@dimen/size_spacing_24"
+            android:layout_marginTop="@dimen/size_spacing_12"
+            android:paddingVertical="@dimen/size_spacing_12"
             android:text="@string/setting_privacy_policy"
+            android:textAppearance="@style/TextView.Setting.TextAppearance_16"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_terms_policies" />
 

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -21,20 +21,20 @@
             android:id="@+id/iv_back"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/size_spacing_20"
-            android:layout_marginTop="@dimen/size_spacing_13"
+            android:layout_marginStart="5dp"
+            android:padding="@dimen/size_spacing_15"
             android:src="@drawable/ic_before"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/tv_setting_title"
-            style="@style/TextView.Setting.TextAppearance_16"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/size_spacing_18"
+            android:layout_marginTop="@dimen/size_spacing_15"
+            android:fontFamily="@font/notosanskr_b"
             android:text="@string/setting_title"
-            android:textStyle="bold"
+            android:textAppearance="@style/TextView.Setting.TextAppearance_16"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -43,7 +43,6 @@
             android:id="@+id/line_first"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_marginTop="@dimen/size_spacing_13"
             android:background="@color/gray_200"
             app:layout_constraintTop_toBottomOf="@id/iv_back" />
 
@@ -53,22 +52,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/size_spacing_20"
-            android:layout_marginTop="@dimen/size_spacing_24"
+            android:layout_marginTop="32dp"
             android:text="@string/setting_customer_support"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/line_first" />
-
-        <!-- TODO 배치 수정 필요 -->
-        <TextView
-            android:id="@+id/tv_privacy_policy"
-            style="@style/TextView.Setting.TextAppearance_16"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/size_spacing_24"
-            android:layout_marginHorizontal="@dimen/size_spacing_20"
-            android:text="@string/setting_privacy_policy"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_customer_support" />
 
         <TextView
             android:id="@+id/tv_inquiry"
@@ -76,10 +63,21 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/size_spacing_20"
-            android:layout_marginTop="@dimen/size_spacing_36"
+            android:layout_marginTop="@dimen/size_spacing_24"
             android:text="@string/setting_inquiry"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_privacy_policy" />
+            app:layout_constraintTop_toBottomOf="@id/tv_customer_support" />
+
+        <TextView
+            android:id="@+id/tv_declaration"
+            style="@style/TextView.Setting.TextAppearance_16"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/size_spacing_20"
+            android:layout_marginTop="@dimen/size_spacing_36"
+            android:text="@string/setting_declaration"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_inquiry" />
 
         <TextView
             android:id="@+id/tv_withdrawal"
@@ -91,18 +89,29 @@
             android:text="@string/setting_withdrawal"
             android:visibility="@{viewModel.getIsGuestLogin() ? View.GONE : View.VISIBLE}"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_inquiry" />
+            app:layout_constraintTop_toBottomOf="@id/tv_declaration" />
 
         <TextView
-            android:id="@+id/tv_declaration"
+            android:id="@+id/tv_terms_policies"
+            style="@style/TextView.Setting.TextAppearance_14"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/size_spacing_20"
+            android:layout_marginTop="76dp"
+            android:text="@string/setting_terms_policies"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_withdrawal" />
+
+        <TextView
+            android:id="@+id/tv_privacy_policy"
             style="@style/TextView.Setting.TextAppearance_16"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/size_spacing_20"
-            android:text="@string/setting_declaration"
+            android:layout_marginTop="@dimen/size_spacing_24"
+            android:text="@string/setting_privacy_policy"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_inquiry"
-            app:layout_marginTop="@{viewModel.getIsGuestLogin() ? 36 : 88}" />
+            app:layout_constraintTop_toBottomOf="@id/tv_terms_policies" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## Related issue 🚀
- closed #422

## Work Description 💚
- 설정탭 레이아웃 둘러보기 분기 처리 // 레이아웃 배치 수정
- 기존에 전체적인 버튼과 메뉴의 터치 영역이 좁게 잡혀 있어 터치 영역을 확장했습니다!

## Screenshot 📸
- 소셜로그인 진입
<img width="236" alt="image" src="https://user-images.githubusercontent.com/48701368/193954673-75d12e0e-7a06-494a-ab31-d993e2ad9322.png">

- 둘러보기 진입
<img width="238" alt="image" src="https://user-images.githubusercontent.com/48701368/193954762-b0370878-2d1a-45a0-a742-3ed67bbcaacf.png">

