### PR TITLE
[mod] 상세뷰 외식대처법 엠티뷰 분기처리 로직 수정

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/MainViewModel.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainViewModel.kt
@@ -242,6 +242,10 @@ class MainViewModel @Inject constructor(
         return !(boardList.isNullOrEmpty() || boardList == listOf(""))
     }
 
+    fun isExistEatingOutTips(eatingOutTip: EatingOutTipInfo): Boolean {
+        return !(eatingOutTip.recommendTips.isNullOrEmpty() || eatingOutTip.eatingTips == listOf(""))
+    }
+
     fun fetchHFMReviewList() {
         viewModelScope.launch(Dispatchers.IO) {
             _hfmReviews.postValue(

--- a/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantEatingOutTabFragment.kt
+++ b/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantEatingOutTabFragment.kt
@@ -7,7 +7,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.helfoome.R
 import org.helfoome.databinding.FragmentEatingOutBinding
 import org.helfoome.presentation.MainViewModel
-import org.helfoome.presentation.restaurant.adapter.RestaurantMenuAdapter
 import org.helfoome.util.binding.BindingFragment
 
 @AndroidEntryPoint

--- a/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantEatingOutTabFragment.kt
+++ b/app/src/main/java/org/helfoome/presentation/restaurant/RestaurantEatingOutTabFragment.kt
@@ -13,19 +13,9 @@ import org.helfoome.util.binding.BindingFragment
 @AndroidEntryPoint
 class RestaurantEatingOutTabFragment : BindingFragment<FragmentEatingOutBinding>(R.layout.fragment_eating_out) {
     private val viewModel: MainViewModel by activityViewModels()
-    private val restaurantMenuAdapter = RestaurantMenuAdapter()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
-
-        initObservers()
-    }
-
-    private fun initObservers() {
-        viewModel.menu.observe(viewLifecycleOwner) { menuList ->
-            if (menuList == null) return@observe
-            restaurantMenuAdapter.menuList = menuList
-        }
     }
 }

--- a/app/src/main/res/layout/fragment_eating_out.xml
+++ b/app/src/main/res/layout/fragment_eating_out.xml
@@ -111,7 +111,7 @@
                             android:id="@+id/layout_content"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
-                            app:visibility="@{viewModel.eatingOutTips.size() > 0}">
+                            app:visibility="@{viewModel.eatingOutTips.size() > 0 &amp;&amp; viewModel.isExistEatingOutTips(viewModel.eatingOutTips.get(viewModel.selectedFoodCategoryIdx))}">
 
                             <ImageView
                                 android:id="@+id/iv_reason_for_recommendation"
@@ -197,7 +197,7 @@
                         <include
                             android:id="@+id/layout_empty_view"
                             layout="@layout/view_eating_out_empty"
-                            app:visibility="@{viewModel.eatingOutTips.size() == 0}"
+                            app:visibility="@{!viewModel.isExistEatingOutTips(viewModel.eatingOutTips.get(viewModel.selectedFoodCategoryIdx))}"
                             tools:visibility="gone" />
                     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## Related issue 🚀
- closed #428

## Work Description 💚
- 상세뷰 외식대처법 엠티뷰 분기처리 로직 수정
   - 선택된 카테고리에 해당하는 외식대처법이 존재하지 않을 경우 empty뷰가 보이도록 수정했습니다!
 
- 불필요한 코드 제거
   - 외식대처법 탭인데 메뉴 탭에서 사용되는 restaurantMenuAdapter에 menu 아이템을 submitList하고 있음..

## Screenshot 📸
<img width="201" alt="image" src="https://user-images.githubusercontent.com/48701368/194529240-8011508e-663f-4ea0-80a8-23640bfbbe69.png">
