### PR TITLE
[feat] 이미지 뷰어에서 이미지 저장 기능 구현

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/common/ImageViewerActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/common/ImageViewerActivity.kt
@@ -116,7 +116,7 @@ class ImageViewerActivity : BindingActivity<ActivityImageViewerBinding>(R.layout
         }
         fos?.use {
             bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it)
-            showToast("이미지 다운이 완료되었습니다")
+            showToast("사진이 저장되었습니다")
         }
     }
 

--- a/app/src/main/java/org/helfoome/presentation/common/ImageViewerActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/common/ImageViewerActivity.kt
@@ -1,22 +1,40 @@
 package org.helfoome.presentation.common
 
+import android.content.ContentValues
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.helfoome.R
 import org.helfoome.databinding.ActivityImageViewerBinding
 import org.helfoome.util.binding.BindingActivity
+import org.helfoome.util.ext.showToast
+import java.io.*
+import java.net.HttpURLConnection
+import java.net.URL
 
 @AndroidEntryPoint
 class ImageViewerActivity : BindingActivity<ActivityImageViewerBinding>(R.layout.activity_image_viewer) {
     private val adapter = PhotoSlideAdapter()
     private var position = 0
-
+    private var imageList: List<String>? = null
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         intent.let {
-            it.getStringArrayExtra(ARG_IMAGE_LIST)?.let { adapter.submitList(it.toMutableList()) }
+            it.getStringArrayExtra(ARG_IMAGE_LIST)?.let {
+                imageList = it.toList()
+                adapter.submitList(it.toMutableList())
+            }
             it.getIntExtra(ARG_IMAGE_POSITION, 0).let { position = it }
         }
 
@@ -44,12 +62,62 @@ class ImageViewerActivity : BindingActivity<ActivityImageViewerBinding>(R.layout
         binding.btnClose.setOnClickListener {
             finish()
         }
+
+        binding.tvSave.setOnClickListener {
+            lifecycleScope.launch {
+                val bitmap = getBitmapFromURL(imageList?.get(position) ?: return@launch)
+                bitmap?.let { saveMediaToStorage(bitmap) }
+            }
+        }
     }
 
     private fun setPosition(smoothScroll: Boolean) {
         val indicator = "${position + 1}/${adapter.itemCount}"
         binding.page.text = indicator
         binding.vpPhotoList.setCurrentItem(position, smoothScroll)
+    }
+
+    private suspend fun getBitmapFromURL(src: String): Bitmap? {
+        val bitmap: Bitmap?
+        withContext(Dispatchers.IO) {
+            bitmap = try {
+                val url = URL(src)
+                val connection: HttpURLConnection = url.openConnection() as HttpURLConnection
+                connection.doInput = true
+                connection.connect()
+                val input: InputStream = connection.inputStream
+                BitmapFactory.decodeStream(input)
+            } catch (e: IOException) {
+                e.printStackTrace()
+                null
+            }
+        }
+
+        return bitmap
+    }
+
+    private fun saveMediaToStorage(bitmap: Bitmap) {
+        val filename = "${System.currentTimeMillis()}.jpg"
+        var fos: OutputStream? = null
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            this.contentResolver?.also { resolver ->
+                val contentValues = ContentValues().apply {
+                    put(MediaStore.MediaColumns.DISPLAY_NAME, filename)
+                    put(MediaStore.MediaColumns.MIME_TYPE, "image/jpg")
+                    put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_PICTURES)
+                }
+                val imageUri: Uri? = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+                fos = imageUri?.let { resolver.openOutputStream(it) }
+            }
+        } else {
+            val imagesDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+            val image = File(imagesDir, filename)
+            fos = FileOutputStream(image)
+        }
+        fos?.use {
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it)
+            showToast("이미지 다운이 완료되었습니다")
+        }
     }
 
     companion object {


### PR DESCRIPTION
## Related issue 🚀
- closed #446

## Work Description 💚
- 이미지 뷰어에서 우측 상단 저장 버튼 누를 경우 해당 페이지의 이미지를 저장하는 기능을 구현했습니다!
- 토스트 문구 스트링 추출은 추후 리팩토링 시 진행하겠습니다.. 빠른 apk 전달을 위해..
