### PR TITLE
[fix] 플레이스토어에서 애플리케이션 다운로드 되지않는 버그 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -95,11 +95,7 @@
                     android:host="oauth"
                     android:scheme="kakao8483f545857597ac5a551516e471a131" />
             </intent-filter>
-        </activity> <!-- leakcanary 안드로이드 12 부터 버전충돌 문제 해결 -->
-        <activity-alias
-            android:name="leakcanary.internal.activity.LeakLauncherActivity"
-            android:exported="false"
-            android:targetActivity="leakcanary.internal.activity.LeakActivity" />
+        </activity>
 
         <activity
             android:name=".presentation.MainActivity"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 okhttp-loggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 timber = "com.jakewharton.timber:timber:5.0.1"
-leakCanary = "com.squareup.leakcanary:leakcanary-android:2.6"
+leakCanary = "com.squareup.leakcanary:leakcanary-android:2.9.1"
 lottie = "com.airbnb.android:lottie:3.6.0"
 kotlin-serialization-converter = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0"
 naverlogin = "com.navercorp.nid:oauth:5.1.1"


### PR DESCRIPTION
## Related issue 🚀
- closed #451 

## Work Description 💚
- 릭카나리로 인해 플레이스토어에서 설치 안되는 버그 수정
  - 릭 카나리는 디버그용 메모리 릭 디텍션 라이브러리
  - 현재는 버전이 낮아서 매니페스트에 액티비티를 alias해주는 식으로 처리하고 있었음(안드로이드 12부터 exported 속성 강제때문에)
  - 릴리즈 apk에는 alias가 없으니 에러 발생
  - 릭 카나리 버전 업시 해당 부분 해결
