### PR TITLE
[fix] - 메뉴탭, 외식대처법 탭에서도 리뷰쓰기 버튼이 보이는 버그 수정

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/MainViewModel.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainViewModel.kt
@@ -241,6 +241,7 @@ class MainViewModel @Inject constructor(
                 if (it != null) _menuBoard.value = it
                 _isExistMenuBoard.value = isExistMenuBoard(it)
             }
+            _isReviewTab.value = Event(false)
         }
     }
 


### PR DESCRIPTION
## Related issue 🚀
- closed #465

## Work Description 💚
- 선택된 레스토랑이 바뀔 때마다 새로운 프래그먼트로 전환되는 것이 아닌 데이터를 교체하여 레스토랑 디테일 정보를 보여주고 있습니다!
만약 식당 A에서 리뷰탭을 보고 바로 B식당으로 이동하면 리뷰쓰기 버튼이 보이게되는데요..! 그 이유는 마지막에 본 탭이 리뷰탭이기 때문에 리뷰 탭으로 착각하고 리뷰쓰기를 보여주는 것이죠.. 그래서 새로운 레스토랑 정보를 불러올 때 리뷰탭 여부를 false로 초기화해서 버그를 수정했습니다..
새로운 레스토랑을 클릭할 때 변경되어야하는 값들이 상당히 많습니다.. 리팩토링 시 고민을 해봐야할 것 같네용..
