### PR TITLE
[feat] 중심좌표 이동 시 핀 재호출 로직 추가

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/MainActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainActivity.kt
@@ -457,7 +457,9 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                 CameraPosition(LatLng(EOUNJU_X, EOUNJU_Y), 12.0)
             }
 
-            addOnCameraChangeListener { reason, _ ->
+            addOnCameraChangeListener { _, _ ->
+                if(!binding.btnBookmarkMain.isSelected)
+                    viewModel.getMapInfo(naverMap.cameraPosition.target, checkedChip)
             }
         }
         viewModel.getMapInfo(naverMap.cameraPosition.target)

--- a/app/src/main/java/org/helfoome/presentation/MainActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/MainActivity.kt
@@ -458,7 +458,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
             }
 
             addOnCameraChangeListener { _, _ ->
-                if(!binding.btnBookmarkMain.isSelected)
+                if (!binding.btnBookmarkMain.isSelected)
                     viewModel.getMapInfo(naverMap.cameraPosition.target, checkedChip)
             }
         }


### PR DESCRIPTION
## Related issue 🚀
- closed #466

## Work Description 💚
- 메인 뷰에서 중심좌표 이동 시 핀 재호출이 이뤄지게 바꿨습니다.
- 줌 체인지 리스너 사용

## Screenshot 📸
<img src = https://user-images.githubusercontent.com/70698151/194748032-bb656566-d877-4925-bc98-900e340e331a.png width = 200>

(gif가 용량문제로 안올라가서 사진으로 대체합니다. 영등포 주변으로 이동시 영등포 주변 식당이 뜹니다. 1km 반경)

