### PR TITLE
[fix] 내가 쓴 리뷰 > 리뷰 아이템 > 식당명 클릭 시 이동하는 상세뷰에서 요약정보 뷰일 때 보이는 상단 다이얼로그 라인이 보이는 버그 수정

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/drawer/MyReviewActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/drawer/MyReviewActivity.kt
@@ -44,6 +44,8 @@ class MyReviewActivity : BindingActivity<ActivityMyReviewBinding>(R.layout.activ
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         viewModel.getMyReviewList()
+        // 리뷰 아이템에서 레스토랑 명 클릭 시 상세화면으로 넘어갈 때 상단 회색 라인이 보이지 않도록 하기 위함. 해당 속성으로 상단 회색 라인의 visibility 조절하고 있기 때문
+        mainViewModel.setExpendedBottomSheetDialog(true)
 
         initAdapter()
         initObservers()


### PR DESCRIPTION
## Related issue 🚀
- closed #471

## Work Description 💚
- 내가 쓴 리뷰 > 리뷰 아이템 > 식당명 클릭 시 이동하는 상세뷰에서 요약정보 뷰일 때 보이는 상단 다이얼로그 라인이 보이는 버그 수정
   - 상단에 다이얼로그 회색 라인의 visibility에 에 관여하는 속성 값을 변경 mainViewModel.setExpendedBottomSheetDialog(true) 호출

## Screenshot 📸
- 변경 전 (상단바 바로 아래의 회색 라인을 주목해주세요 👀)
<img src="https://user-images.githubusercontent.com/48701368/194751419-102b644e-8c95-4310-9b25-d9e37324d69c.jpg" width="360" />
- 변경 후
<img width="360" alt="image" src="https://user-images.githubusercontent.com/48701368/194751599-3cbb21f0-0651-4070-9c80-352f6708943e.png">

