### PR TITLE
[fix] - #478 스크랩한 식당에서 식당 목록이 없을 때 Empty뷰가 보이지 않는 버그 수정

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/scrap/ScrapViewModel.kt
+++ b/app/src/main/java/org/helfoome/presentation/scrap/ScrapViewModel.kt
@@ -78,7 +78,8 @@ class ScrapViewModel @Inject constructor(
         }
     }
 
-    private fun List<ScrapInfo>.toScrapUiState() = ScrapUiState.Success(this)
+    private fun List<ScrapInfo>.toScrapUiState() =
+        if (this.isEmpty()) ScrapUiState.Empty else ScrapUiState.Success(this)
 
     sealed class ScrapUiState {
         object Loading : ScrapUiState()


### PR DESCRIPTION
## Related issue 🚀
- closed #478

## Work Description 💚
- 스크랩한 식당에서 식당 목록이 없을 때 Empty뷰가 보이지 않는 버그 수정
   - 기존에 스크랩목록 api 요청(근데 필터링된 스크랩 목록임) 시 스크랩한 식당을 빈리스트로 보내줄 때도 ScrapUiState.Success로 처리했던 것이 원인이었습니다! 빈리스트인 경우는 ScrapUiState.Empty로 처리하도록 수정했습니다 :)

```kotlin
 private fun List<ScrapInfo>.toScrapUiState() =
        if (this.isEmpty()) ScrapUiState.Empty else ScrapUiState.Success(this)
```
   - MyScrapActivity > onStart()에서 해당 api를 호출하고 있음 -> 사연이 매우 깊음
   - 일반 스크랩 목록을 불러오는 api에서는 이미 리스트가 비어있는지 검사하고 있어서 해당 api를 호출하는 함수내에서 toScrapUiState()를 적용하면 Empty 리스트 검사가 중복으로 일어나게 됨 ㅎㅎ 그냥 전체적으로 리펙토링이 필요해서 주석을 남기진 않았습니다 ^^
