### PR TITLE
[feat] 검색화면에 기획 플로우 잘못 적용된 부분 수정

### DIFF
--- a/app/src/main/java/org/helfoome/presentation/search/SearchActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/search/SearchActivity.kt
@@ -178,7 +178,7 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
                 else
                     binding.layoutSearch.visibility = View.VISIBLE
                 searchMapTopAdapter.setVisible(this)
-                if(searchViewModel.searchMode.value != SearchMode.RESULT)
+                if (searchViewModel.searchMode.value != SearchMode.RESULT)
                     behavior.isDraggable = this
                 binding.isLineVisible = this
                 mainViewModel.setExpendedBottomSheetDialog(newState == BottomSheetBehavior.STATE_EXPANDED)
@@ -445,7 +445,7 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
                                         captionText = markerInfo.name
 
                                         setOnClickListener {
-                                            if(behavior.state == BottomSheetBehavior.STATE_COLLAPSED && !searchViewModel.isDetail.value)
+                                            if (behavior.state == BottomSheetBehavior.STATE_COLLAPSED && !searchViewModel.isDetail.value)
                                                 prevResultCollapsed = true
                                             searchViewModel.setDetail(true)
                                             mainViewModel.getReviewCheck(markerInfo.id)
@@ -610,7 +610,7 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
             uiSettings.isZoomControlEnabled = false
             setOnMapClickListener { _, _ ->
                 if (searchViewModel.isDetail.value) {
-                    if(prevResultCollapsed)
+                    if (prevResultCollapsed)
                         searchViewModel.setDetail(false)
                     else
                         behavior.state = BottomSheetBehavior.STATE_HIDDEN

--- a/app/src/main/java/org/helfoome/presentation/search/SearchActivity.kt
+++ b/app/src/main/java/org/helfoome/presentation/search/SearchActivity.kt
@@ -44,6 +44,7 @@ import javax.inject.Inject
 class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_search), OnMapReadyCallback {
     // TODO : Inject 로직 수정 요망
     private var isAutoCompleteResult = false
+    private var prevResultCollapsed = false
 
     @Inject
     lateinit var resolutionMetrics: ResolutionMetrics
@@ -157,7 +158,6 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
                     )
                 }
             }
-            behavior.isDraggable = false
         } else {
             behavior.peekHeight = resolutionMetrics.toPixel(135)
             behavior.state = BottomSheetBehavior.STATE_COLLAPSED
@@ -167,7 +167,6 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
                     12.0
                 )
             }
-            behavior.isDraggable = true
         }
     }
     private val searchRecentTopAdapter = SearchRecentTopAdapter()
@@ -179,7 +178,8 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
                 else
                     binding.layoutSearch.visibility = View.VISIBLE
                 searchMapTopAdapter.setVisible(this)
-                behavior.isDraggable = this
+                if(searchViewModel.searchMode.value != SearchMode.RESULT)
+                    behavior.isDraggable = this
                 binding.isLineVisible = this
                 mainViewModel.setExpendedBottomSheetDialog(newState == BottomSheetBehavior.STATE_EXPANDED)
                 if (newState == BottomSheetBehavior.STATE_COLLAPSED)
@@ -241,7 +241,7 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
         binding.layoutRestaurantListDialog.rvSearch.itemAnimator = null
         behavior = BottomSheetBehavior.from(binding.layoutBottomSheet)
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
-        behavior.isDraggable = false
+        behavior.isHideable = false
     }
 
     private fun initClickEvent() {
@@ -445,6 +445,8 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
                                         captionText = markerInfo.name
 
                                         setOnClickListener {
+                                            if(behavior.state == BottomSheetBehavior.STATE_COLLAPSED && !searchViewModel.isDetail.value)
+                                                prevResultCollapsed = true
                                             searchViewModel.setDetail(true)
                                             mainViewModel.getReviewCheck(markerInfo.id)
                                             mainViewModel.fetchSelectedRestaurantDetailInfo(
@@ -501,9 +503,11 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
                             behavior.state = BottomSheetBehavior.STATE_COLLAPSED
                         }
                         else -> {
+                            behavior.peekHeight = resolutionMetrics.toPixel(135)
                             binding.etSearch.isEnabled = true
-                            behavior.isHideable = false
                             binding.isDetail = false
+                            behavior.isHideable = false
+                            prevResultCollapsed = false
                             remove()
                         }
                     }
@@ -605,8 +609,12 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
         this.naverMap = naverMap.apply {
             uiSettings.isZoomControlEnabled = false
             setOnMapClickListener { _, _ ->
-                if (searchViewModel.isDetail.value)
-                    behavior.state = BottomSheetBehavior.STATE_HIDDEN
+                if (searchViewModel.isDetail.value) {
+                    if(prevResultCollapsed)
+                        searchViewModel.setDetail(false)
+                    else
+                        behavior.state = BottomSheetBehavior.STATE_HIDDEN
+                }
                 markerList.forEach {
                     it.first.icon = OverlayImage.fromResource(
                         if (it.second.isDietRestaurant) R.drawable.ic_marker_green_small

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -77,7 +77,7 @@
                 android:layout_height="match_parent"
                 android:fillViewport="true"
                 android:overScrollMode="never"
-                app:behavior_hideable="true"
+                app:behavior_hideable="false"
                 app:behavior_peekHeight="304dp"
                 app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
                 tools:visibility="visible">


### PR DESCRIPTION
## Related issue 🚀
- closed #487

## Work Description 💚
- [x] 검색 후 핀 누르고, 지도화면 누르면 “하단 목록보기” 떠야함
- [x] [검색결과목록]에서 슬라이드 내려서 하단목록보기 형태로 변환돼야함
- 두 가지 버그 수정