### PR TITLE
[fix] Menu 데이터 클래스에서 kcal 프로퍼티를 Int -> Float로 변경

### DIFF
--- a/app/src/main/java/org/helfoome/data/model/response/ResponseRestaurantDetail.kt
+++ b/app/src/main/java/org/helfoome/data/model/response/ResponseRestaurantDetail.kt
@@ -36,7 +36,7 @@ data class ResponseRestaurantDetail(
         val image: String,
         val price: Int,
         val isPick: Boolean,
-        val kcal: Int? = null,
+        val kcal: Float? = null,
         val per: Int? = null,
     )
 
@@ -52,7 +52,7 @@ data class ResponseRestaurantDetail(
         contact = restaurant.contact,
         distance = restaurant.distance,
         menuList = menuList?.map { menu ->
-            MenuInfo(menu.id, menu.name, menu.image, menu.price, menu.kcal, menu.per, menu.isPick)
+            MenuInfo(menu.id, menu.name, menu.image, menu.price, menu.kcal?.toInt(), menu.per, menu.isPick)
         },
         score = restaurant.score
     )


### PR DESCRIPTION
## Related issue 🚀
- closed #500 

## Work Description 💚
- 기존에 Menu 데이터 클래스에서 kcal 프로퍼티의 데이터 타입이 Int였고, 서버에서는 칼로리를 실수 타입으로 전달해줄 때 타입 불일치로 식당 정보를 불러오지 못한 것이 버그 원인
- ResponseRestaurantDetail 에서 칼로리를 Float타입으로 변경하고, RestaurantInfo로 변환 시 소수점을 제거하는 것(Float.toInt() 적용)으로 해결
